### PR TITLE
Implement unit testing for Day Controller

### DIFF
--- a/back-end/config/debug.js
+++ b/back-end/config/debug.js
@@ -1,7 +1,7 @@
 import config from "./config.js";
 // do not use with sensitive data
-export function debugLog(message) {
+export function debugLog(message, label = "DEBUG") {
   if (config.debug) {
-    console.info(`DEBUG: ${message}`);
+    console.info(`[${label}] ${message}`);
   }
 }

--- a/back-end/src/controller/DayController.js
+++ b/back-end/src/controller/DayController.js
@@ -1,9 +1,108 @@
 /* The Day Controller places calls to Model */
 /* DayRoutes.js tells the Day Controller which calls to place  */
+import ModelFactory from "../model/ModelFactory.js";
+import { debugLog } from "../../config/debug.js";
 
 class DayController {
-  /* TODO */
+  constructor() {
+    this.initializeModel("local");
+  }
+
+  async initializeModel(modelType) {
+    try {
+      this.model = await ModelFactory.getModel(modelType);
+      debugLog(`DayController initialized with ${this.model.name}`);
+    } catch (err) {
+      debugLog(`Error initializing DayController: ${err}`);
+    }
+  }
+
+  setModel(model) {
+    this.model = model;
+  }
+
+  /** Author: Nikolay Ostroukhov @nikozbk
+   *  Retrieves all data from the model and sends it as a JSON response.
+   *  Logs the process and handles any errors that occur.
+   *
+   *  @param {Object} req - The request object.
+   *  @param {Object} res - The response object.
+   *  @returns {Promise<void>} - A promise that resolves when the data is sent or an error is handled.
+   */
+  async getAllData(req, res) {
+    debugLog(`DayController.getAllData`);
+    try {
+      const data = await this.model.read();
+      debugLog(`Returning data: ${JSON.stringify(data)}`);
+      res.setHeader("Content-Type", "application/json");
+      res.json(data);
+    } catch (err) {
+      debugLog(`Error in DayController.getAllData: ${err}`);
+      res
+        .status(500)
+        .send("Error retrieving data from DayController.getAllData");
+    }
+  }
+
+  async getAllUsers(req, res) {
+    debugLog(`DayController.getAllUsers`);
+    // TODO: Implement this method
+  }
+
+  async getUserByUsername(req, res) {
+    debugLog(`DayController.getUserByUsername`);
+    // TODO: Implement this method
+  }
+
+  async registerUser(req, res) {
+    debugLog(`DayController.registerUser`);
+    // TODO: Implement this method
+  }
+
+  async loginUser(req, res) {
+    debugLog(`DayController.loginUser`);
+    // TODO: Implement this method
+  }
+
+  async postUserData(req, res) {
+    debugLog(`DayController.postUserData`);
+    // TODO: Implement this method
+  }
+
+  async getUserData(req, res) {
+    debugLog(`DayController.getUserData`);
+    // TODO: Implement this method
+  }
+
+  async postDay(req, res) {
+    debugLog(`DayController.postDay`);
+    // TODO: Implement this method
+  }
+
+  async getDay(req, res) {
+    debugLog(`DayController.getDay`);
+    // TODO: Implement this method
+  }
+
+  async getDaysOfMonth(req, res) {
+    debugLog(`DayController.getDaysOfMonth`);
+    // TODO: Implement this method
+  }
+
+  async getDaysOfYear(req, res) {
+    debugLog(`DayController.getDaysOfYear`);
+    // TODO: Implement this method
+  }
+
+  async addEmotion(req, res) {
+    debugLog(`DayController.addEmotion`);
+    // TODO: Implement this method
+  }
+
+  async deleteEmotion(req, res) {
+    debugLog(`DayController.deleteEmotion`);
+    // TODO: Implement this method
+  }
 }
 
-const DayController = new DayController();
-export default DayController;
+export default new DayController();

--- a/back-end/src/model/LocalDayModel.js
+++ b/back-end/src/model/LocalDayModel.js
@@ -8,6 +8,7 @@ import { debugLog } from "../../config/debug.js";
 
 class _LocalDayModel {
   constructor() {
+    this.name = "LocalDayModel";
     this.dateData = [];
     this.date_id = getToday();
   }

--- a/back-end/src/model/ModelFactory.js
+++ b/back-end/src/model/ModelFactory.js
@@ -1,8 +1,10 @@
 /* The Model Factory Lets Us Swap Between Models */
 /* We can use the local model at first and swap to the SQLite model later */
+import LocalDayModel from "./LocalDayModel.js";
+import SQLiteDayModel from "./SQLiteDayModel.js";
 
 class _ModelFactory {
-  async getModel(model = "sqlite") {
+  async getModel(model = "local") {
     switch (model) {
       case "local":
         return LocalDayModel;
@@ -17,5 +19,4 @@ class _ModelFactory {
   }
 }
 
-const ModelFactory = new _ModelFactory();
-export default ModelFactory;
+export default new _ModelFactory();

--- a/back-end/src/model/SQLiteDayModel.js
+++ b/back-end/src/model/SQLiteDayModel.js
@@ -3,7 +3,10 @@
 /* Sequelize code goes here */
 
 class _SQLiteDayModel {
-  /* TODO */
+  constructor() {
+    this.name = "SQLiteDayModel";
+    // this.init();
+  }
 }
 const SQLiteDayModel = new _SQLiteDayModel();
 export default SQLiteDayModel;

--- a/back-end/src/spec/DayController-spec.js
+++ b/back-end/src/spec/DayController-spec.js
@@ -1,0 +1,47 @@
+import DayController from "../controller/DayController.js";
+import ModelFactory from "../model/ModelFactory.js";
+import { createMockRequestResponse } from "../spec/helpers/mockRequestResponse.js";
+
+describe("DayController", () => {
+  let mockModel;
+
+  beforeAll(async () => {
+    mockModel = {
+      read: jasmine.createSpy("read"),
+      create: jasmine.createSpy("create"),
+      delete: jasmine.createSpy("delete"),
+      update: jasmine.createSpy("update"),
+    };
+    spyOn(ModelFactory, "getModel").and.returnValue(Promise.resolve(mockModel));
+    DayController.setModel(mockModel);
+  });
+
+  describe("getAllData", () => {
+    it("should return all data from the model", async () => {
+      const { req, res } = createMockRequestResponse();
+      const mockData = [{ date_id: "1-1-11" }];
+      mockModel.read.and.returnValue(Promise.resolve(mockData));
+
+      await DayController.getAllData(req, res);
+
+      expect(mockModel.read).toHaveBeenCalled();
+      expect(res.setHeader).toHaveBeenCalledWith(
+        "Content-Type",
+        "application/json"
+      );
+      expect(res.json).toHaveBeenCalledWith(mockData);
+    });
+
+    it("should handle errors and send a 500 status", async () => {
+      const { req, res } = createMockRequestResponse();
+      const mockError = "Error retrieving data from DayController.getAllData";
+      mockModel.read.and.returnValue(Promise.reject(mockError));
+
+      await DayController.getAllData(req, res);
+
+      expect(mockModel.read).toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.status().send).toHaveBeenCalledWith(mockError);
+    });
+  });
+});

--- a/back-end/src/spec/helpers/mockRequestResponse.js
+++ b/back-end/src/spec/helpers/mockRequestResponse.js
@@ -1,0 +1,15 @@
+export function createMockRequestResponse(params = {}) {
+  const req = {
+    body: params,
+  };
+  const res = {
+    status: jasmine.createSpy("status").and.returnValue({
+      json: jasmine.createSpy("json"),
+      send: jasmine.createSpy("send"),
+    }),
+    json: jasmine.createSpy("json"),
+    send: jasmine.createSpy("send"),
+    setHeader: jasmine.createSpy("setHeader"),
+  };
+  return { req, res };
+}

--- a/front-end/src/config/debug.js
+++ b/front-end/src/config/debug.js
@@ -1,7 +1,7 @@
 import config from "./config.js";
 // do not use with sensitive data
-export function debugLog(message) {
+export function debugLog(message, label = "DEBUG") {
   if (config.debug) {
-    console.log(`DEBUG: ${message}`);
+    console.info(`[${label}] ${message}`);
   }
 }

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,12 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "../back-end/src/spec/**/*[sS]pec.?(m)js",
+    "../front-end/src/spec/**/*[sS]pec.?(m)js"
+  ],
+  "helpers": ["helpers/**/*.?(m)js"],
+  "env": {
+    "stopSpecOnExpectationFailure": false,
+    "random": true
+  }
+}


### PR DESCRIPTION
I wanted to push a working unit test for the day controller so that we can debug our functions. Be sure to run "npm install" to get the dependencies. I opted to use jasmine because jasmine is fully compatible with ESM modules whereas jest has experimental support that is tricky to run.

You can run tests with the command `npm test` or if you install the extensions below you can easily run tests by clicking on the green check mark:
![image](https://github.com/user-attachments/assets/d86a4d8a-1339-4e64-a53f-d890b199536b)


I recommend the following extensions:

Name: Test Explorer UI
Id: hbenl.vscode-test-explorer
Description: Run your tests in the Sidebar of Visual Studio Code
Version: 2.22.1
Publisher: Holger Benl
VS Marketplace Link: https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-test-explorer 

Name: Test Adapter Converter
Id: ms-vscode.test-adapter-converter
Description: Converter extension from the Test Adapter UI to native VS Code testing
Version: 0.2.1
Publisher: Microsoft
VS Marketplace Link: https://marketplace.visualstudio.com/items?itemName=ms-vscode.test-adapter-converter

Name: Jasmine Test Explorer
Id: hbenl.vscode-jasmine-test-adapter
Description: Run your Jasmine tests in the Sidebar of Visual Studio Code
Version: 1.8.2
Publisher: Holger Benl
VS Marketplace Link: https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-jasmine-test-adapter
